### PR TITLE
Display Unescaped SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This will make a QrCode that says "Make me into a QrCode!"
 
 	{{ QrCode::generate('Make me into a QrCode!'); }}
 	
-__Important:__ Laravel 5 by default will escape the svg when using {{}}. Please use `{!! !!}}` instead.	
+__Important:__ Laravel 5 by default will escape the svg when using {{}}. Please use `{!! !!}` instead.	
 	
 
 The `generate` method has a second parameter that will accept a filename and path to save the QrCode.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ This will make a QrCode that says "Make me into a QrCode!"
 `Generate` by default will return a SVG image string.  You can print this directly into a modern browser within Laravel's Blade system with the following:
 
 	{{ QrCode::generate('Make me into a QrCode!'); }}
+	
+__Important:__ Laravel 5 by default will escape the svg when using {{}}. Please use `{!! !!}}` instead.	
+	
 
 The `generate` method has a second parameter that will accept a filename and path to save the QrCode.
 


### PR DESCRIPTION
With L5, `{{}}` will escape all output and show the svg source instead. You'll have to use `{!! !!}`, but be careful with data supplied by users.