### PR TITLE
Fixed merge() method for users who dont use Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,14 @@ Change the character encoding that is used to build a QrCode.  By default `ISO-8
 The `merge` method merges an image over a QrCode.  This is commonly used to placed logos within a QrCode.
 
     QrCode::merge($filename, $percentage);
-    
+
     //Generates a QrCode with an image centered in the middle.
     QrCode::format('png')->merge('path-to-image.png')->generate();
-    
+
     //Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
     QrCode::format('png')->merge('path-to-image.png', .3)->generate();
 
->The `merge` method only supports PNG at this time. The 'merge' path is relative to app base path.
+>The `merge` method only supports PNG at this time. The 'merge' path is relative to app base path. If you are outside of Laravel pass absolute path.
 
 >You should use a high level of error correction when using the `merge` method to ensure that the QrCode is still readable.  We recommend using `errorCorrection('H')`.
 

--- a/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
+++ b/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
@@ -96,12 +96,21 @@ class BaconQrCodeGenerator implements QrCodeInterface {
     /**
      * Merges an image with the center of the QrCode
      *
-     * @param $image string The filepath to an image
+     * @param string $image The filepath to an image (relative path for Laravel otherwise absolute)
+     * @param float $percentage The inserted image takes up 20% of the QrCode
      * @return $this
      */
     public function merge($image, $percentage = .2)
     {
-        $this->imageMerge = file_get_contents(base_path() . $image);
+        $filename = function_exists('base_path')
+            ? base_path() . $image
+            : $image;
+
+        if (!file_exists($filename)) {
+            throw new \InvalidArgumentException("Invalid image argument. File '$filename' does not exists.");
+        }
+
+        $this->imageMerge = file_get_contents($filename);
         $this->imagePercentage = $percentage;
 
         return $this;


### PR DESCRIPTION
Hi, 

first, thank you for your library! I've tested some client-side libs, then looked for some server-side QR generators in PHP and this is the best!

I would like to use it with another framework ([Nette Framework](https://nette.org/)) but this framework does not have helper `base_path()`. I think this is only in Laravel. Could you merge this patch?

Thank you!