### PR TITLE
Added a call to make sure that we can use the storage facade and updated the readme to also show this call

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,20 @@ The `merge` method merges an image over a QrCode.  This is commonly used to plac
 
 >You should use a high level of error correction when using the `merge` method to ensure that the QrCode is still readable.  We recommend using `errorCorrection('H')`.
 
+#### Merge binary string
+
+The `mergeString` method can be used to achieve the same as the `merge` call, except it allows you to provide a string representation of the file instead of the filepath. This is usefull when working with the `Storage` facade. It's interface is quite similar to the `merge` call. 
+
+    QrCode::mergeString(Storage::get('path/to/image.png'), $percentage);
+    
+    //Generates a QrCode with an image centered in the middle.
+    QrCode::format('png')->mergeString(Storage::get('path/to/image.png'))->generate();
+    
+    //Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
+    QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3)->generate();
+
+>As with the normal `merge` call, only PNG is supported at this time. The same applies for error correction, high levels are recommened.
+
 ![Merged Logo](https://raw.githubusercontent.com/SimpleSoftwareIO/simple-qrcode/master/docs/imgs/merged-qrcode.png?raw=true)
 
 #### Advance Usage

--- a/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
+++ b/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
@@ -115,6 +115,21 @@ class BaconQrCodeGenerator implements QrCodeInterface {
     }
 
     /**
+     * Merges an image string with the center of the QrCode, does not check for correct format
+     *
+     * @param $image string The string contents of an image
+     * @param $percentage float The amount that the merged image should be placed over the qrcode.
+     * @return $this
+     */
+    public function mergeString($content, $percentage = .2)
+    {
+        $this->imageMerge = $content;
+        $this->imagePercentage = $percentage;
+
+        return $this;
+    }
+
+    /**
      * Switches the format of the outputted QrCode or defaults to SVG
      *
      * @param string $format The desired format.


### PR DESCRIPTION
In Laravel many people make use of the Storage facade, unfortunately there is no proper way to retrieve a full path for every different driver which can be used.

In this commit a new method has been introduced which simply accepts a binary string and stores that as the to be merged image; instead of retrieving the file contents ourselves.