### PR TITLE
Allow a resample image merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ One of the main items that we use this package for is to have QrCodes in all of 
 
 You may embed a qrcode inside of an e-mail to allow your users to quickly scan.  The following is an example of how to do this with Laravel.
 
-    //Inside of a blade template.
+	//Inside of a blade template.
 	<img src="{!!$message->embedData(QrCode::format('png')->generate('Embed me into an e-mail!'), 'QrCode.png', 'image/png')!!}">
 
 <a id="docs-usage"></a>
@@ -117,7 +117,7 @@ Three formats are currently supported; PNG, EPS, and SVG.  To change the format 
 
 You can change the size of a QrCode by using the `size` method. Simply specify the size desired in pixels using the following syntax:
 
-    QrCode::size(100);
+	QrCode::size(100);
 
 #### Color Change
 
@@ -158,7 +158,7 @@ The following are supported options for the `errorCorrection` method.
 
 Change the character encoding that is used to build a QrCode.  By default `ISO-8859-1` is selected as the encoder.  Read more about [character encoding](http://en.wikipedia.org/wiki/Character_encoding) You can change this to any of the following:
 
-    QrCode::encoding('UTF-8')->generate('Make me a QrCode with special symbols ♠♥!!');
+	QrCode::encoding('UTF-8')->generate('Make me a QrCode with special symbols ♠♥!!');
 
 | Character Encoder |
 | --- |
@@ -195,35 +195,51 @@ Change the character encoding that is used to build a QrCode.  By default `ISO-8
 
 The `merge` method merges an image over a QrCode.  This is commonly used to placed logos within a QrCode.
 
-    QrCode::merge($filename, $percentage, $absolute);
-    
-    //Generates a QrCode with an image centered in the middle.
-    QrCode::format('png')->merge('path-to-image.png')->generate();
-    
-    //Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
-    QrCode::format('png')->merge('path-to-image.png', .3)->generate();
-    
-    //Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
-    QrCode::format('png')->merge('http://www.google.com/someimage.png', .3, true)->generate();
+	QrCode::merge($filename, $percentage, $absolute);
+	
+	//Generates a QrCode with an image centered in the middle.
+	QrCode::format('png')->merge('path-to-image.png')->generate();
+	
+	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
+	QrCode::format('png')->merge('path-to-image.png', .3)->generate();
+	
+	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
+	QrCode::format('png')->merge('http://www.google.com/someimage.png', .3, true)->generate();
+
+	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.  Image is merged using resampling, to increase merge quality
+	QrCode::format('png')->merge('http://www.google.com/someimage.png', .3, true, true)->generate();
 
 >The `merge` method only supports PNG at this time.
 >The filepath is relative to app base path if `$absolute` is set to `false`.  Change this variable to `true` to use absolute paths.
 
 >You should use a high level of error correction when using the `merge` method to ensure that the QrCode is still readable.  We recommend using `errorCorrection('H')`.
 
+>When using the higher quality of merging, note that this can have an impact on performance when generating many QR codes since the resample algorithm is more complex (and time-consuming) than the simply resize algorithm.
+
 #### Merge binary string
 
 The `mergeString` method can be used to achieve the same as the `merge` call, except it allows you to provide a string representation of the file instead of the filepath. This is usefull when working with the `Storage` facade. It's interface is quite similar to the `merge` call. 
 
-    QrCode::mergeString(Storage::get('path/to/image.png'), $percentage);
-    
-    //Generates a QrCode with an image centered in the middle.
-    QrCode::format('png')->mergeString(Storage::get('path/to/image.png'))->generate();
-    
-    //Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
-    QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3)->generate();
+	QrCode::mergeString(Storage::get('path/to/image.png'), $percentage);
+	
+	//Generates a QrCode with an image centered in the middle.
+	QrCode::format('png')->mergeString(Storage::get('path/to/image.png'))->generate();
+	
+	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
+	QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3)->generate();
 
->As with the normal `merge` call, only PNG is supported at this time. The same applies for error correction, high levels are recommened.
+	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.  
+	//Image is merged using resampling to increase merge quality
+	QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3, true)->generate();
+
+>As with the normal `merge` call, only PNG is supported at this time. The same applies for error correction, high levels are recommened. Also the higher quality can have an impact on performance.
+
+#### Merge quality
+Normally the merging of an image is done using a "simple" merge algorithm. Since this can result in a (slightly) warped image, the option for a higher quality merge is available. This uses a resampler which yields better looking results, but reduces performance of the generator. The quality can be increased using 2 methods. Either by using the parameters in the `merge` and `mergeString` calls; or by using the method: `setMergeQuality` which takes a boolean specifiying whether resample merge needs to be applied.
+
+	//Generates a QrCode with an image centered in the middle and apply the resample algorithm instead of the
+	//resize algorithm
+	QrCode::setMergeQuality(true)->merge('http://www.google.com/someimage.png')->generate();
 
 ![Merged Logo](https://raw.githubusercontent.com/SimpleSoftwareIO/simple-qrcode/master/docs/imgs/merged-qrcode.png?raw=true)
 
@@ -347,7 +363,7 @@ You can use a prefix found in the table below inside the `generate` section to c
 
 You may use this package outside of Laravel by instantiating a new `BaconQrCodeGenerator` class.
 
-    use SimpleSoftwareIO\QrCode\BaconQrCodeGenerator;
+	use SimpleSoftwareIO\QrCode\BaconQrCodeGenerator;
 
-    $qrcode = new BaconQrCodeGenerator;
-    $qrcode->size(500)->generate('Make a qrcode without Laravel!');
+	$qrcode = new BaconQrCodeGenerator;
+	$qrcode->size(500)->generate('Make a qrcode without Laravel!');

--- a/README.md
+++ b/README.md
@@ -206,15 +206,10 @@ The `merge` method merges an image over a QrCode.  This is commonly used to plac
 	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
 	QrCode::format('png')->merge('http://www.google.com/someimage.png', .3, true)->generate();
 
-	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.  Image is merged using resampling, to increase merge quality
-	QrCode::format('png')->merge('http://www.google.com/someimage.png', .3, true, true)->generate();
-
 >The `merge` method only supports PNG at this time.
 >The filepath is relative to app base path if `$absolute` is set to `false`.  Change this variable to `true` to use absolute paths.
 
 >You should use a high level of error correction when using the `merge` method to ensure that the QrCode is still readable.  We recommend using `errorCorrection('H')`.
-
->When using the higher quality of merging, note that this can have an impact on performance when generating many QR codes since the resample algorithm is more complex (and time-consuming) than the simply resize algorithm.
 
 #### Merge binary string
 
@@ -228,18 +223,7 @@ The `mergeString` method can be used to achieve the same as the `merge` call, ex
 	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.
 	QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3)->generate();
 
-	//Generates a QrCode with an image centered in the middle.  The inserted image takes up 30% of the QrCode.  
-	//Image is merged using resampling to increase merge quality
-	QrCode::format('png')->mergeString(Storage::get('path/to/image.png'), .3, true)->generate();
-
->As with the normal `merge` call, only PNG is supported at this time. The same applies for error correction, high levels are recommened. Also the higher quality can have an impact on performance.
-
-#### Merge quality
-Normally the merging of an image is done using a "simple" merge algorithm. Since this can result in a (slightly) warped image, the option for a higher quality merge is available. This uses a resampler which yields better looking results, but reduces performance of the generator. The quality can be increased using 2 methods. Either by using the parameters in the `merge` and `mergeString` calls; or by using the method: `setMergeQuality` which takes a boolean specifiying whether resample merge needs to be applied.
-
-	//Generates a QrCode with an image centered in the middle and apply the resample algorithm instead of the
-	//resize algorithm
-	QrCode::setMergeQuality(true)->merge('http://www.google.com/someimage.png')->generate();
+>As with the normal `merge` call, only PNG is supported at this time. The same applies for error correction, high levels are recommened.
 
 ![Merged Logo](https://raw.githubusercontent.com/SimpleSoftwareIO/simple-qrcode/master/docs/imgs/merged-qrcode.png?raw=true)
 

--- a/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
+++ b/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
@@ -58,13 +58,6 @@ class BaconQrCodeGenerator implements QrCodeInterface {
     protected $imagePercentage = .2;
 
     /**
-     * Whether the quality of the merge has to of high quality (resampled)
-     *
-     * @var bool
-     */
-    protected $highQuality = false;
-
-    /**
      * Creates a new QrCodeGenerator with a Writer class and with a SVG renderer set as the default.
      */
     public function __construct(Writer $writer = null, RendererInterface $format = null)
@@ -86,7 +79,7 @@ class BaconQrCodeGenerator implements QrCodeInterface {
 
         if ($this->imageMerge !== null)
         {
-            $merger = new ImageMerge(new Image($qrCode), new Image($this->imageMerge), $this->highQuality);
+            $merger = new ImageMerge(new Image($qrCode), new Image($this->imageMerge));
             $qrCode = $merger->merge($this->imagePercentage);
         }
 
@@ -106,19 +99,13 @@ class BaconQrCodeGenerator implements QrCodeInterface {
      * @param $filepath string The filepath to an image
      * @param $percentage float The amount that the merged image should be placed over the qrcode.
      * @param $absolute boolean Whether to use an absolute filepath or not.
-     * @param $highQuality boolean Whether we want a high merge quality (resampled vs just resized).
      * @return $this
      */
-    public function merge($filepath, $percentage = .2, $absolute = false, $highQuality = false)
+    public function merge($filepath, $percentage = .2, $absolute = false)
     {
         if (function_exists('base_path') && ! $absolute)
         {
             $filepath = base_path() . $filepath;
-        }
-
-        if( ! is_null($highQuality))
-        {
-            $this->highQuality = true && $highQuality;
         }
 
         $this->imageMerge = file_get_contents($filepath);
@@ -132,32 +119,12 @@ class BaconQrCodeGenerator implements QrCodeInterface {
      *
      * @param $content string The string contents of an image.
      * @param $percentage float The amount that the merged image should be placed over the qrcode.
-     * @param $highQuality boolean Whether we want a high merge quality (resampled vs just resized).
      * @return $this
      */
-    public function mergeString($content, $percentage = .2, $highQuality = null)
+    public function mergeString($content, $percentage = .2)
     {
         $this->imageMerge = $content;
         $this->imagePercentage = $percentage;
-
-        if(!is_null($highQuality))
-        {
-            $this->highQuality = true && $highQuality;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Sets the quality of the merge, when set to true the merge will use a resampled merge, when set to false will set
-     * the merge to a simple resized merge. The resampled merge will yield a higher quality due to anti-aliassing, but
-     * takes more CPU time to compute
-     *
-     * @param $highQuality boolean Whether the quality should be high (true) or low (false)
-     * @return $this
-     */
-    public function setMergeQuality($highQuality){
-        $this->highQuality = true && $highQuality;
 
         return $this;
     }

--- a/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
+++ b/src/SimpleSoftwareIO/QrCode/BaconQrCodeGenerator.php
@@ -106,19 +106,19 @@ class BaconQrCodeGenerator implements QrCodeInterface {
      * @param $filepath string The filepath to an image
      * @param $percentage float The amount that the merged image should be placed over the qrcode.
      * @param $absolute boolean Whether to use an absolute filepath or not.
-     * @param $hq boolean Whether we want a high merge quality (resampled vs just resized).
+     * @param $highQuality boolean Whether we want a high merge quality (resampled vs just resized).
      * @return $this
      */
-    public function merge($filepath, $percentage = .2, $absolute = false, $hq = false)
+    public function merge($filepath, $percentage = .2, $absolute = false, $highQuality = false)
     {
         if (function_exists('base_path') && ! $absolute)
         {
             $filepath = base_path() . $filepath;
         }
 
-        if(!is_null($hq))
+        if( ! is_null($highQuality))
         {
-            $this->highQuality = true && $hq;
+            $this->highQuality = true && $highQuality;
         }
 
         $this->imageMerge = file_get_contents($filepath);
@@ -132,17 +132,17 @@ class BaconQrCodeGenerator implements QrCodeInterface {
      *
      * @param $content string The string contents of an image.
      * @param $percentage float The amount that the merged image should be placed over the qrcode.
-     * @param $hq boolean Whether we want a high merge quality (resampled vs just resized).
+     * @param $highQuality boolean Whether we want a high merge quality (resampled vs just resized).
      * @return $this
      */
-    public function mergeString($content, $percentage = .2, $hq = null)
+    public function mergeString($content, $percentage = .2, $highQuality = null)
     {
         $this->imageMerge = $content;
         $this->imagePercentage = $percentage;
 
-        if(!is_null($hq))
+        if(!is_null($highQuality))
         {
-            $this->highQuality = true && $hq;
+            $this->highQuality = true && $highQuality;
         }
 
         return $this;
@@ -153,11 +153,11 @@ class BaconQrCodeGenerator implements QrCodeInterface {
      * the merge to a simple resized merge. The resampled merge will yield a higher quality due to anti-aliassing, but
      * takes more CPU time to compute
      *
-     * @param $hq boolean Whether the quality should be high (true) or low (false)
+     * @param $highQuality boolean Whether the quality should be high (true) or low (false)
      * @return $this
      */
-    public function setMergeQuality($hq){
-        $this->highQuality = true && $hq;
+    public function setMergeQuality($highQuality){
+        $this->highQuality = true && $highQuality;
 
         return $this;
     }

--- a/src/SimpleSoftwareIO/QrCode/ImageMerge.php
+++ b/src/SimpleSoftwareIO/QrCode/ImageMerge.php
@@ -81,28 +81,38 @@ class ImageMerge implements ImageMergeInterface {
     protected $centerX;
 
     /**
+     * Whether the quality of the merge has to of high quality (resampled)
+     *
+     * @var bool
+     */
+    protected $highQuality;
+
+    /**
      * Creates a new ImageMerge object.
      *
      * @param $sourceImage Image The image that will be merged over.
      * @param $mergeImage Image The image that will be used to merge with $sourceImage
+     * @param $hq boolean Whether the image merge needs to be of high quality (resampled)
      */
-    function __construct(Image $sourceImage, Image $mergeImage)
+    function __construct(Image $sourceImage, Image $mergeImage, $hq = false)
     {
         $this->sourceImage = $sourceImage;
         $this->mergeImage = $mergeImage;
+        $this->highQuality = $hq;
     }
 
     /**
      * Returns an QrCode that has been merge with another image.
      * This is usually used with logos to imprint a logo into a QrCode
      *
+     * @param $percentage float The percentage of size relative to the entire QR of the merged image
      * @return str
      */
     public function merge($percentage)
     {
         $this->setProperties($percentage);
 
-        imagecopyresized(
+        $parameters = [
             $this->sourceImage->getImageResource(),
             $this->mergeImage->getImageResource(),
             $this->centerX,
@@ -113,7 +123,11 @@ class ImageMerge implements ImageMergeInterface {
             $this->postMergeImageHeight,
             $this->mergeImageWidth,
             $this->mergeImageHeight
-        );
+        ];
+
+        $call = $this->highQuality ? 'imagecopyresampled' : 'imagecopyresized';
+
+        call_user_func_array($call, $parameters);
 
         return $this->createImage();
     }

--- a/src/SimpleSoftwareIO/QrCode/ImageMerge.php
+++ b/src/SimpleSoftwareIO/QrCode/ImageMerge.php
@@ -81,24 +81,15 @@ class ImageMerge implements ImageMergeInterface {
     protected $centerX;
 
     /**
-     * Whether the quality of the merge has to of high quality (resampled)
-     *
-     * @var bool
-     */
-    protected $highQuality;
-
-    /**
      * Creates a new ImageMerge object.
      *
      * @param $sourceImage Image The image that will be merged over.
      * @param $mergeImage Image The image that will be used to merge with $sourceImage
-     * @param $hq boolean Whether the image merge needs to be of high quality (resampled)
      */
-    function __construct(Image $sourceImage, Image $mergeImage, $hq = false)
+    function __construct(Image $sourceImage, Image $mergeImage)
     {
         $this->sourceImage = $sourceImage;
         $this->mergeImage = $mergeImage;
-        $this->highQuality = $hq;
     }
 
     /**
@@ -112,7 +103,7 @@ class ImageMerge implements ImageMergeInterface {
     {
         $this->setProperties($percentage);
 
-        $parameters = [
+        imagecopyresampled(
             $this->sourceImage->getImageResource(),
             $this->mergeImage->getImageResource(),
             $this->centerX,
@@ -123,11 +114,7 @@ class ImageMerge implements ImageMergeInterface {
             $this->postMergeImageHeight,
             $this->mergeImageWidth,
             $this->mergeImageHeight
-        ];
-
-        $call = $this->highQuality ? 'imagecopyresampled' : 'imagecopyresized';
-
-        call_user_func_array($call, $parameters);
+        );
 
         return $this->createImage();
     }

--- a/tests/ImageMergeTest.php
+++ b/tests/ImageMergeTest.php
@@ -67,7 +67,7 @@ class ImageMergeTest extends \PHPUnit_Framework_TestCase {
         $merge = imagecreatefromstring($this->testImagePath);
 
         //Create a PNG and place the image in the middle using 20% of the area.
-        imagecopyresized(
+        imagecopyresampled(
             $source,
             $merge,
             204,
@@ -85,45 +85,6 @@ class ImageMergeTest extends \PHPUnit_Framework_TestCase {
         file_put_contents($this->testImageSaveLocation, $testImage);
 
         $this->assertEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation));
-    }
-
-    public function test_if_increasing_quality_changes_final_image()
-    {
-        //We know the test image is 512x512
-        $source = imagecreatefromstring($this->testImagePath);
-        $merge = imagecreatefromstring($this->testImagePath);
-
-        //Create a PNG and place the image in the middle using 20% of the area.
-        imagecopyresampled(
-            $source,
-            $merge,
-            204,
-            204,
-            0,
-            0,
-            102,
-            102,
-            512,
-            512
-        );
-        imagepng($source, $this->compareTestSaveLocation);
-
-        $localTestImage = new ImageMerge(
-            new Image($this->testImagePath),
-            new Image($this->testImagePath),
-            true
-        );
-
-        $testImage = $localTestImage->merge(.2);
-        file_put_contents($this->testImageSaveLocation.'.resampled', $testImage);
-
-        $testImage = $this->testImage->merge(.2);
-        file_put_contents($this->testImageSaveLocation, $testImage);
-
-        $this->assertEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation.'.resampled'));
-
-        // Verify that the results are actually different
-        $this->assertNotEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation));
     }
 
     /**

--- a/tests/ImageMergeTest.php
+++ b/tests/ImageMergeTest.php
@@ -56,6 +56,7 @@ class ImageMergeTest extends \PHPUnit_Framework_TestCase {
     public function tearDown()
     {
         @unlink($this->testImageSaveLocation);
+        @unlink($this->testImageSaveLocation.'.resampled');
         @unlink($this->compareTestSaveLocation);
     }
 
@@ -84,6 +85,45 @@ class ImageMergeTest extends \PHPUnit_Framework_TestCase {
         file_put_contents($this->testImageSaveLocation, $testImage);
 
         $this->assertEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation));
+    }
+
+    public function test_if_increasing_quality_changes_final_image()
+    {
+        //We know the test image is 512x512
+        $source = imagecreatefromstring($this->testImagePath);
+        $merge = imagecreatefromstring($this->testImagePath);
+
+        //Create a PNG and place the image in the middle using 20% of the area.
+        imagecopyresampled(
+            $source,
+            $merge,
+            204,
+            204,
+            0,
+            0,
+            102,
+            102,
+            512,
+            512
+        );
+        imagepng($source, $this->compareTestSaveLocation);
+
+        $localTestImage = new ImageMerge(
+            new Image($this->testImagePath),
+            new Image($this->testImagePath),
+            true
+        );
+
+        $testImage = $localTestImage->merge(.2);
+        file_put_contents($this->testImageSaveLocation.'.resampled', $testImage);
+
+        $testImage = $this->testImage->merge(.2);
+        file_put_contents($this->testImageSaveLocation, $testImage);
+
+        $this->assertEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation.'.resampled'));
+
+        // Verify that the results are actually different
+        $this->assertNotEquals(file_get_contents($this->compareTestSaveLocation), file_get_contents($this->testImageSaveLocation));
     }
 
     /**


### PR DESCRIPTION
Instead of using the "simple" resize algorithm the resample algorithm
can also be used when merging an image into the QR code. When the
resampler is used, we get an anti-aliased merge and therefor a more
pretty final result. The parameter that was added to the merge calls
are always forced to be a boolean when they have to be set. This was
done to be consistent with PHP's handling of "true-ness" for
variables, while still having the internal variable as a strict type.

The workaround for not doing this is generating a large QR code with
a merged image and finaly scaling that back. (Or letting the browser
handle this step)

Another testcase was created to verify that setting the quality value
in the ImageMerge class will actually yield a resampled and different
result from the normal merge.

The calls implemented in the facade have been documented in the
readme and have a small description in code (where applicable). Some
minor changes were made in the in-code documentation to reflect name
changes etc. I also made the indentation in the readme consistent.
It appeared that mainly tabs were used, so all instances of 4 spaces
have been replaced with 1 tab.