### PR TITLE
Regular bind service instead of singleton.

### DIFF
--- a/src/SimpleSoftwareIO/QrCode/QrCodeServiceProvider.php
+++ b/src/SimpleSoftwareIO/QrCode/QrCodeServiceProvider.php
@@ -18,7 +18,7 @@ class QrCodeServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('qrcode', function () {
+        $this->app->bind('qrcode', function () {
             return new BaconQrCodeGenerator();
         });
     }


### PR DESCRIPTION
Binding as a regular service instead of singleton avoids issues with the generation of QRCodes multiple times within the same execution thread