### PR TITLE
Email fix

### DIFF
--- a/src/SimpleSoftwareIO/QrCode/DataTypes/Email.php
+++ b/src/SimpleSoftwareIO/QrCode/DataTypes/Email.php
@@ -68,7 +68,8 @@ class Email implements DataTypeInterface
                 'subject' => $this->subject,
                 'body'    => $this->body,
             ];
-            $email .= '?'.http_build_query($data);
+            $email =  $email.'?subject='.$data['subject'].'&body='.$data['body'];
+        };
         }
 
         return $email;

--- a/src/SimpleSoftwareIO/QrCode/DataTypes/Email.php
+++ b/src/SimpleSoftwareIO/QrCode/DataTypes/Email.php
@@ -69,7 +69,6 @@ class Email implements DataTypeInterface
                 'body'    => $this->body,
             ];
             $email =  $email.'?subject='.$data['subject'].'&body='.$data['body'];
-        };
         }
 
         return $email;


### PR DESCRIPTION
Changed how email string is generated. Which stops the subject & body sting using "+" instead of a space