### PR TITLE
Fix creating a transparent qr code

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -533,7 +533,7 @@ class Generator
      */
     public function createColor(int $red, int $green, int $blue, ?int $alpha = null): ColorInterface
     {
-        if (! $alpha) {
+        if (is_null($alpha)) {
             return new Rgb($red, $green, $blue);
         }
 


### PR DESCRIPTION
This PR fixes a bug where passing 0 as alpha to a color returns an Rgb color instance since 0 evaluates to false in php. By checking the alpha with `is_null`, passing 0 correctly returns an alpha instance with 0 percent opacity.

This PR fixes #172 