### PR TITLE
Add support for returning Illuminate\Support\HtmlString

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -181,7 +181,7 @@ class Generator
             return;
         }
 
-        if(class_exists(\Illuminate\Support\HtmlString::class)){
+        if (class_exists(\Illuminate\Support\HtmlString::class)) {
             return new \Illuminate\Support\HtmlString($qrCode);
         }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -162,7 +162,7 @@ class Generator
      *
      * @param string $text
      * @param string|null $filename
-     * @return void|string
+     * @return void|Illuminate\Support\HtmlString|string
      * @throws WriterException
      * @throws InvalidArgumentException
      */
@@ -179,6 +179,10 @@ class Generator
             file_put_contents($filename, $qrCode);
 
             return;
+        }
+
+        if(class_exists(\Illuminate\Support\HtmlString::class)){
+            return new \Illuminate\Support\HtmlString($qrCode);
         }
 
         return $qrCode;

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -205,4 +205,10 @@ class GeneratorTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         (new Generator)->notReal('fooBar');
     }
+
+    public function test_generator_can_return_illuminate_support_htmlstring()
+    {
+        $this->getMockBuilder(\Illuminate\Support\HtmlString::class)->getMock();
+        $this->assertInstanceOf(\Illuminate\Support\HtmlString::class, (new Generator)->generate('fooBar'));
+    }
 }


### PR DESCRIPTION
Closes #182

Added check for existence of Illuminate\Support\HtmlString and return that class if available. 

Test added as well.