### PR TITLE
Add QR Code in Base64 encoding for KSA E-Invoicing

### DIFF
--- a/src/DataTypes/BTC.php
+++ b/src/DataTypes/BTC.php
@@ -116,7 +116,7 @@ class BTC implements DataTypeInterface
         $query = http_build_query([
             'amount'    => $this->amount,
             'label'     => $this->label,
-            'message'  => $this->message,
+            'message'   => $this->message,
             'r'         => $this->returnAddress,
         ]);
 

--- a/src/DataTypes/Email.php
+++ b/src/DataTypes/Email.php
@@ -113,7 +113,7 @@ class Email implements DataTypeInterface
      */
     protected function isValidEmail($email)
     {
-        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw new InvalidArgumentException('Invalid email provided');
         }
 

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -100,7 +100,7 @@ class KSAVat implements DataTypeInterface
         $result .= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
         $result .= chr(4).chr(strlen($this->total)).$this->total;
         $result .= chr(5).chr(strlen($this->tax)).$this->tax;
-        
+
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -75,7 +75,7 @@ class KSAVat implements DataTypeInterface
             $this->seller_name = $arguments['seller'];
         }
         if (isset($arguments['vat'])) {
-            $this->vat_nr= $arguments['vat'];
+            $this->vat_nr = $arguments['vat'];
         }
         if (isset($arguments['date'])) {
             $this->invoice_date = $arguments['date'];
@@ -95,11 +95,11 @@ class KSAVat implements DataTypeInterface
      */
     public function __toString()
     {
-        $result = chr(1) . chr(strlen($this->seller_name)) . $this->seller_name;
-        $result.= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
-        $result.= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
-        $result.= chr(4) . chr(strlen($this->total)) . $this->total;
-        $result.= chr(5) . chr(strlen($this->tax)) . $this->tax;
+        $result = chr(1).chr(strlen($this->seller_name)).$this->seller_name;
+        $result.= chr(2).chr(strlen($this->vat_nr)).$this->vat_nr;
+        $result.= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
+        $result.= chr(4).chr(strlen($this->total)).$this->total;
+        $result.= chr(5).chr(strlen($this->tax)).$this->tax;
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -95,11 +95,11 @@ class KSAVat implements DataTypeInterface
      */
     public function __toString()
     {
-        $result = chr(1) . chr(strlen($this->seller_name)) . $this->seller_name;
-        $result .= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
-        $result .= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
-        $result .= chr(4) . chr(strlen($this->total)) . $this->total;
-        $result .= chr(5) . chr(strlen($this->tax)) . $this->tax;
+        $result = chr(1).chr(strlen($this->seller_name)).$this->seller_name;
+        $result .= chr(2).chr(strlen($this->vat_nr)).$this->vat_nr;
+        $result .= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
+        $result .= chr(4).chr(strlen($this->total)).$this->total;
+        $result .= chr(5).chr(strlen($this->tax)).$this->tax;
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -101,6 +101,7 @@ class KSAVat implements DataTypeInterface
         $result .= chr(4).chr(strlen($this->total)).$this->total;
         $result .= chr(5).chr(strlen($this->tax)).$this->tax;
         
+        
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -75,7 +75,7 @@ class KSAVat implements DataTypeInterface
             $this->seller_name = $arguments['seller'];
         }
         if (isset($arguments['vat'])) {
-            $this->vat_nr= $arguments['vat'];
+            $this->vat_nr = $arguments['vat'];
         }
         if (isset($arguments['date'])) {
             $this->invoice_date = $arguments['date'];
@@ -96,10 +96,10 @@ class KSAVat implements DataTypeInterface
     public function __toString()
     {
         $result = chr(1) . chr(strlen($this->seller_name)) . $this->seller_name;
-        $result.= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
-        $result.= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
-        $result.= chr(4) . chr(strlen($this->total)) . $this->total;
-        $result.= chr(5) . chr(strlen($this->tax)) . $this->tax;
+        $result .= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
+        $result .= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
+        $result .= chr(4) . chr(strlen($this->total)) . $this->total;
+        $result .= chr(5) . chr(strlen($this->tax)) . $this->tax;
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -63,7 +63,7 @@ class KSAVat implements DataTypeInterface
         $this->setProperties($arguments);
     }
 
-        /**
+    /**
      * Sets the KSAVat properties.
      *
      * @param $arguments

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -96,10 +96,10 @@ class KSAVat implements DataTypeInterface
     public function __toString()
     {
         $result = chr(1).chr(strlen($this->seller_name)).$this->seller_name;
-        $result.= chr(2).chr(strlen($this->vat_nr)).$this->vat_nr;
-        $result.= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
-        $result.= chr(4).chr(strlen($this->total)).$this->total;
-        $result.= chr(5).chr(strlen($this->tax)).$this->tax;
+        $result .= chr(2).chr(strlen($this->vat_nr)).$this->vat_nr;
+        $result .= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
+        $result .= chr(4).chr(strlen($this->total)).$this->total;
+        $result .= chr(5).chr(strlen($this->tax)).$this->tax;
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -75,7 +75,7 @@ class KSAVat implements DataTypeInterface
             $this->seller_name = $arguments['seller'];
         }
         if (isset($arguments['vat'])) {
-            $this->vat_nr = $arguments['vat'];
+            $this->vat_nr= $arguments['vat'];
         }
         if (isset($arguments['date'])) {
             $this->invoice_date = $arguments['date'];
@@ -95,12 +95,11 @@ class KSAVat implements DataTypeInterface
      */
     public function __toString()
     {
-        $result = chr(1).chr(strlen($this->seller_name)).$this->seller_name;
-        $result .= chr(2).chr(strlen($this->vat_nr)).$this->vat_nr;
-        $result .= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
-        $result .= chr(4).chr(strlen($this->total)).$this->total;
-        $result .= chr(5).chr(strlen($this->tax)).$this->tax;
-        
+        $result = chr(1) . chr(strlen($this->seller_name)) . $this->seller_name;
+        $result.= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
+        $result.= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
+        $result.= chr(4) . chr(strlen($this->total)) . $this->total;
+        $result.= chr(5) . chr(strlen($this->tax)) . $this->tax;
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -101,7 +101,6 @@ class KSAVat implements DataTypeInterface
         $result .= chr(4).chr(strlen($this->total)).$this->total;
         $result .= chr(5).chr(strlen($this->tax)).$this->tax;
         
-        
         return base64_encode($result);
     }
 }

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace SimpleSoftwareIO\QrCode\DataTypes;
+
+class KSAVat implements DataTypeInterface
+{
+    /**
+     * The prefix of the QrCode.
+     *
+     * @var string
+     */
+    protected $prefix = 'ksa_vat:';
+
+    /**
+     * The separator between the variables.
+     *
+     * @var string
+     */
+    protected $separator = '##';
+
+    /**
+     * Seller’s name.
+     *
+     * @var
+     */
+    protected $seller_name;
+
+    /**
+     * VAT registration number of the seller.
+     *
+     * @var
+     */
+    protected $vat_nr;
+
+    /**
+     * Time stamp of the invoice (date and time).
+     *
+     * @var
+     */
+    protected $invoice_date;
+
+    /**
+     * Invoice total (with VAT).
+     *
+     * @var
+     */
+    protected $invoice_total;
+
+    /**
+     * VAT total.
+     *
+     * @var
+     */
+    protected $invoice_tax;
+
+    /**
+     * Generates the DataType Object and sets all of its properties.
+     *
+     * @param $arguments
+     */
+    public function create(array $arguments)
+    {
+        $this->setProperties($arguments);
+    }
+
+        /**
+     * Sets the KSAVat properties.
+     *
+     * @param $arguments
+     */
+    protected function setProperties(array $arguments)
+    {
+        $arguments = $arguments[0];
+        if (isset($arguments['seller'])) {
+            $this->seller_name = $arguments['seller'];
+        }
+        if (isset($arguments['vat'])) {
+            $this->vat_nr= $arguments['vat'];
+        }
+        if (isset($arguments['date'])) {
+            $this->invoice_date = $arguments['date'];
+        }
+        if (isset($arguments['total'])) {
+            $this->total = $arguments['total'];
+        }
+        if (isset($arguments['tax'])) {
+            $this->tax = $arguments['tax'];
+        }
+    }
+
+    /**
+     * Returns the correct QrCode format.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = chr(1) . chr(strlen($this->seller_name)) . $this->seller_name;
+        $result.= chr(2) . chr(strlen($this->vat_nr)) . $this->vat_nr;
+        $result.= chr(3) . chr(strlen($this->invoice_date)) . $this->invoice_date;
+        $result.= chr(4) . chr(strlen($this->total)) . $this->total;
+        $result.= chr(5) . chr(strlen($this->tax)) . $this->tax;
+        return base64_encode($result);
+    }
+}

--- a/src/DataTypes/KSAVat.php
+++ b/src/DataTypes/KSAVat.php
@@ -100,6 +100,7 @@ class KSAVat implements DataTypeInterface
         $result .= chr(3).chr(strlen($this->invoice_date)).$this->invoice_date;
         $result .= chr(4).chr(strlen($this->total)).$this->total;
         $result .= chr(5).chr(strlen($this->tax)).$this->tax;
+        
         return base64_encode($result);
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -160,11 +160,13 @@ class Generator
     /**
      * Generates the QrCode.
      *
-     * @param string $text
+     * @param string      $text
      * @param string|null $filename
-     * @return void|\Illuminate\Support\HtmlString|string
+     *
      * @throws WriterException
      * @throws InvalidArgumentException
+     *
+     * @return void|\Illuminate\Support\HtmlString|string
      */
     public function generate(string $text, string $filename = null)
     {
@@ -191,14 +193,15 @@ class Generator
     /**
      * Merges an image over the QrCode.
      *
-     * @param string $filepath
-     * @param float $percentage
+     * @param string                               $filepath
+     * @param float                                $percentage
      * @param SimpleSoftwareIO\QrCode\boolean|bool $absolute
+     *
      * @return Generator
      */
     public function merge(string $filepath, float $percentage = .2, bool $absolute = false): self
     {
-        if (function_exists('base_path') && ! $absolute) {
+        if (function_exists('base_path') && !$absolute) {
             $filepath = base_path().$filepath;
         }
 
@@ -211,8 +214,9 @@ class Generator
     /**
      * Merges an image string with the center of the QrCode.
      *
-     * @param string  $content
-     * @param float $percentage
+     * @param string $content
+     * @param float  $percentage
+     *
      * @return Generator
      */
     public function mergeString(string $content, float $percentage = .2): self
@@ -227,6 +231,7 @@ class Generator
      * Sets the size of the QrCode.
      *
      * @param int $pixels
+     *
      * @return Generator
      */
     public function size(int $pixels): self
@@ -240,12 +245,14 @@ class Generator
      * Sets the format of the QrCode.
      *
      * @param string $format
-     * @return Generator
+     *
      * @throws InvalidArgumentException
+     *
+     * @return Generator
      */
     public function format(string $format): self
     {
-        if (! in_array($format, ['svg', 'eps', 'png'])) {
+        if (!in_array($format, ['svg', 'eps', 'png'])) {
             throw new InvalidArgumentException("\$format must be svg, eps, or png. {$format} is not a valid.");
         }
 
@@ -257,10 +264,11 @@ class Generator
     /**
      * Sets the foreground color of the QrCode.
      *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
+     * @param int      $red
+     * @param int      $green
+     * @param int      $blue
      * @param null|int $alpha
+     *
      * @return Generator
      */
     public function color(int $red, int $green, int $blue, ?int $alpha = null): self
@@ -273,10 +281,11 @@ class Generator
     /**
      * Sets the background color of the QrCode.
      *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
+     * @param int      $red
+     * @param int      $green
+     * @param int      $blue
      * @param null|int $alpha
+     *
      * @return Generator
      */
     public function backgroundColor(int $red, int $green, int $blue, ?int $alpha = null): self
@@ -296,8 +305,10 @@ class Generator
      * @param int $outterRed
      * @param int $outterGreen
      * @param int $outterBlue
-     * @return Generator
+     *
      * @throws InvalidArgumentException
+     *
+     * @return Generator
      */
     public function eyeColor(int $eyeNumber, int $innerRed, int $innerGreen, int $innerBlue, int $outterRed = 0, int $outterGreen = 0, int $outterBlue = 0): self
     {
@@ -329,12 +340,14 @@ class Generator
      * Sets the eye style.
      *
      * @param string $style
-     * @return Generator
+     *
      * @throws InvalidArgumentException
+     *
+     * @return Generator
      */
     public function eye(string $style): self
     {
-        if (! in_array($style, ['square', 'circle'])) {
+        if (!in_array($style, ['square', 'circle'])) {
             throw new InvalidArgumentException("\$style must be square or circle. {$style} is not a valid eye style.");
         }
 
@@ -347,13 +360,15 @@ class Generator
      * Sets the style of the blocks for the QrCode.
      *
      * @param string $style
-     * @param float $size
-     * @return Generator
+     * @param float  $size
+     *
      * @throws InvalidArgumentException
+     *
+     * @return Generator
      */
     public function style(string $style, float $size = 0.5): self
     {
-        if (! in_array($style, ['square', 'dot', 'round'])) {
+        if (!in_array($style, ['square', 'dot', 'round'])) {
             throw new InvalidArgumentException("\$style must be square, dot, or round. {$style} is not a valid.");
         }
 
@@ -377,6 +392,7 @@ class Generator
      * UTF-16BE, UTF-8, ASCII, GBK, EUC-KR.
      *
      * @param string $encoding
+     *
      * @return Generator
      */
     public function encoding(string $encoding): self
@@ -394,6 +410,7 @@ class Generator
      * H: 30% loss.
      *
      * @param string $errorCorrection
+     *
      * @return Generator
      */
     public function errorCorrection(string $errorCorrection): self
@@ -408,6 +425,7 @@ class Generator
      * Sets the margin of the QrCode.
      *
      * @param int $margin
+     *
      * @return Generator
      */
     public function margin(int $margin): self
@@ -421,6 +439,7 @@ class Generator
      * Fetches the Writer.
      *
      * @param ImageRenderer $renderer
+     *
      * @return Writer
      */
     public function getWriter(ImageRenderer $renderer): Writer
@@ -465,10 +484,10 @@ class Generator
         }
 
         if ($this->format === 'eps') {
-            return new EpsImageBackEnd;
+            return new EpsImageBackEnd();
         }
 
-        return new SvgImageBackEnd;
+        return new SvgImageBackEnd();
     }
 
     /**
@@ -529,10 +548,12 @@ class Generator
 
     /**
      * Creates a RGB or Alpha channel color.
-     * @param int $red
-     * @param int $green
-     * @param int $blue
+     *
+     * @param int      $red
+     * @param int      $green
+     * @param int      $blue
      * @param null|int $alpha
+     *
      * @return ColorInterface
      */
     public function createColor(int $red, int $green, int $blue, ?int $alpha = null): ColorInterface
@@ -548,13 +569,14 @@ class Generator
      * Creates a new DataType class dynamically.
      *
      * @param string $method
+     *
      * @return DataTypeInterface
      */
     protected function createClass(string $method): DataTypeInterface
     {
         $class = $this->formatClass($method);
 
-        if (! class_exists($class)) {
+        if (!class_exists($class)) {
             throw new BadMethodCallException();
         }
 
@@ -565,6 +587,7 @@ class Generator
      * Formats the method name correctly.
      *
      * @param $method
+     *
      * @return string
      */
     protected function formatClass(string $method): string

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -17,22 +17,22 @@ class GeneratorTest extends TestCase
 {
     public function test_chaining_is_possible()
     {
-        $this->assertInstanceOf(Generator::class, (new Generator)->size(100));
-        $this->assertInstanceOf(Generator::class, (new Generator)->format('eps'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->color(255, 255, 255));
-        $this->assertInstanceOf(Generator::class, (new Generator)->backgroundColor(255, 255, 255));
-        $this->assertInstanceOf(Generator::class, (new Generator)->eyeColor(0, 255, 255, 255, 0, 0, 0));
-        $this->assertInstanceOf(Generator::class, (new Generator)->gradient(255, 255, 255, 0, 0, 0, 'vertical'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->eye('circle'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->style('round'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->encoding('UTF-8'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->errorCorrection('H'));
-        $this->assertInstanceOf(Generator::class, (new Generator)->margin(2));
+        $this->assertInstanceOf(Generator::class, (new Generator())->size(100));
+        $this->assertInstanceOf(Generator::class, (new Generator())->format('eps'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->color(255, 255, 255));
+        $this->assertInstanceOf(Generator::class, (new Generator())->backgroundColor(255, 255, 255));
+        $this->assertInstanceOf(Generator::class, (new Generator())->eyeColor(0, 255, 255, 255, 0, 0, 0));
+        $this->assertInstanceOf(Generator::class, (new Generator())->gradient(255, 255, 255, 0, 0, 0, 'vertical'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->eye('circle'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->style('round'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->encoding('UTF-8'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->errorCorrection('H'));
+        $this->assertInstanceOf(Generator::class, (new Generator())->margin(2));
     }
 
     public function test_size_is_passed_to_the_renderer()
     {
-        $generator = (new Generator)->size(100);
+        $generator = (new Generator())->size(100);
 
         $this->assertEquals(100, $generator->getRendererStyle()->getSize());
     }
@@ -43,10 +43,10 @@ class GeneratorTest extends TestCase
         // $generator = (new Generator)->format('png');
         // $this->assertInstanceOf(ImagickImageBackEnd::class, $generator->getFormatter());
 
-        $generator = (new Generator)->format('svg');
+        $generator = (new Generator())->format('svg');
         $this->assertInstanceOf(SvgImageBackEnd::class, $generator->getFormatter());
 
-        $generator = (new Generator)->format('eps');
+        $generator = (new Generator())->format('eps');
         $this->assertInstanceOf(EpsImageBackEnd::class, $generator->getFormatter());
     }
 
@@ -54,23 +54,23 @@ class GeneratorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Generator)->format('foo');
+        (new Generator())->format('foo');
     }
 
     public function test_color_is_set()
     {
-        $generator = (new Generator)->color(50, 75, 100);
+        $generator = (new Generator())->color(50, 75, 100);
         $this->assertEquals(50, $generator->getFill()->getForegroundColor()->toRgb()->getRed());
         $this->assertEquals(75, $generator->getFill()->getForegroundColor()->toRgb()->getGreen());
         $this->assertEquals(100, $generator->getFill()->getForegroundColor()->toRgb()->getBlue());
 
-        $generator = (new Generator)->color(50, 75, 100, 25);
+        $generator = (new Generator())->color(50, 75, 100, 25);
         $this->assertEquals(25, $generator->getFill()->getForegroundColor()->getAlpha());
         $this->assertEquals(50, $generator->getFill()->getForegroundColor()->toRgb()->getRed());
         $this->assertEquals(75, $generator->getFill()->getForegroundColor()->toRgb()->getGreen());
         $this->assertEquals(100, $generator->getFill()->getForegroundColor()->toRgb()->getBlue());
 
-        $generator = (new Generator)->color(50, 75, 100, 0);
+        $generator = (new Generator())->color(50, 75, 100, 0);
         $this->assertEquals(0, $generator->getFill()->getForegroundColor()->getAlpha());
         $this->assertEquals(50, $generator->getFill()->getForegroundColor()->toRgb()->getRed());
         $this->assertEquals(75, $generator->getFill()->getForegroundColor()->toRgb()->getGreen());
@@ -79,12 +79,12 @@ class GeneratorTest extends TestCase
 
     public function test_background_color_is_set()
     {
-        $generator = (new Generator)->backgroundColor(50, 75, 100);
+        $generator = (new Generator())->backgroundColor(50, 75, 100);
         $this->assertEquals(50, $generator->getFill()->getBackgroundColor()->toRgb()->getRed());
         $this->assertEquals(75, $generator->getFill()->getBackgroundColor()->toRgb()->getGreen());
         $this->assertEquals(100, $generator->getFill()->getBackgroundColor()->toRgb()->getBlue());
 
-        $generator = (new Generator)->backgroundColor(50, 75, 100, 25);
+        $generator = (new Generator())->backgroundColor(50, 75, 100, 25);
         $this->assertEquals(25, $generator->getFill()->getBackgroundColor()->getAlpha());
         $this->assertEquals(50, $generator->getFill()->getBackgroundColor()->toRgb()->getRed());
         $this->assertEquals(75, $generator->getFill()->getBackgroundColor()->toRgb()->getGreen());
@@ -93,7 +93,7 @@ class GeneratorTest extends TestCase
 
     public function test_eye_color_is_set()
     {
-        $generator = (new Generator)->eyeColor(0, 0, 0, 0, 255, 255, 255);
+        $generator = (new Generator())->eyeColor(0, 0, 0, 0, 255, 255, 255);
         $generator = $generator->eyeColor(1, 0, 0, 0, 255, 255, 255);
         $generator = $generator->eyeColor(2, 0, 0, 0, 255, 255, 255);
 
@@ -111,7 +111,7 @@ class GeneratorTest extends TestCase
         $this->assertEquals(255, $generator->getFill()->getTopRightEyeFill()->getInternalColor()->getGreen());
         $this->assertEquals(255, $generator->getFill()->getTopRightEyeFill()->getInternalColor()->getBlue());
 
-        $generator = (new Generator)->eyeColor(2, 0, 0, 0, 255, 255, 255);
+        $generator = (new Generator())->eyeColor(2, 0, 0, 0, 255, 255, 255);
         $this->assertEquals(0, $generator->getFill()->getBottomLeftEyeFill()->getExternalColor()->getRed());
         $this->assertEquals(0, $generator->getFill()->getBottomLeftEyeFill()->getExternalColor()->getGreen());
         $this->assertEquals(0, $generator->getFill()->getBottomLeftEyeFill()->getExternalColor()->getBlue());
@@ -123,92 +123,92 @@ class GeneratorTest extends TestCase
     public function test_eye_color_throws_exception_with_number_greater_than_2()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->eyeColor(3, 0, 0, 0, 255, 255, 255);
+        (new Generator())->eyeColor(3, 0, 0, 0, 255, 255, 255);
     }
 
     public function test_eye_color_throws_exception_with_negative_number()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->eyeColor(-1, 0, 0, 0, 255, 255, 255);
+        (new Generator())->eyeColor(-1, 0, 0, 0, 255, 255, 255);
     }
 
     public function test_grandient_is_set()
     {
-        $generator = (new Generator)->gradient(0, 0, 0, 255, 255, 255, 'vertical');
+        $generator = (new Generator())->gradient(0, 0, 0, 255, 255, 255, 'vertical');
         $this->assertInstanceOf(Gradient::class, $generator->getFill()->getForegroundGradient());
     }
 
     public function test_eye_style_is_set()
     {
-        $generator = (new Generator)->eye('circle');
+        $generator = (new Generator())->eye('circle');
         $this->assertInstanceOf(SimpleCircleEye::class, $generator->getEye());
 
-        $generator = (new Generator)->eye('square');
+        $generator = (new Generator())->eye('square');
         $this->assertInstanceOf(SquareEye::class, $generator->getEye());
     }
 
     public function test_invalid_eye_throws_an_exception()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->eye('foo');
+        (new Generator())->eye('foo');
     }
 
     public function test_style_is_set()
     {
-        $generator = (new Generator)->style('square');
+        $generator = (new Generator())->style('square');
         $this->assertInstanceOf(SquareModule::class, $generator->getModule());
 
-        $generator = (new Generator)->style('dot', .1);
+        $generator = (new Generator())->style('dot', .1);
         $this->assertInstanceOf(DotsModule::class, $generator->getModule());
 
-        $generator = (new Generator)->style('round', .3);
+        $generator = (new Generator())->style('round', .3);
         $this->assertInstanceOf(RoundnessModule::class, $generator->getModule());
     }
 
     public function test_an_exception_is_thrown_for_an_invalid_style()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->style('foo');
+        (new Generator())->style('foo');
     }
 
     public function test_an_exception_is_thrown_for_a_number_over_1()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->style('round', 1.1);
+        (new Generator())->style('round', 1.1);
     }
 
     public function test_an_exception_is_thrown_for_a_number_under_0()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->style('round', -.1);
+        (new Generator())->style('round', -.1);
     }
 
     public function test_an_exception_is_thrown_for_1()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new Generator)->style('round', 1);
+        (new Generator())->style('round', 1);
     }
 
     public function test_get_renderer_returns_renderer()
     {
-        $this->assertInstanceOf(RendererStyle::class, (new Generator)->getRendererStyle());
+        $this->assertInstanceOf(RendererStyle::class, (new Generator())->getRendererStyle());
     }
 
     public function test_it_calls_a_valid_dynamic_method_and_generates_a_qrcode()
     {
-        $result = (new Generator)->btc('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+        $result = (new Generator())->btc('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
         $this->assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" width=\"100\" height=\"100\" viewBox=\"0 0 100 100\"><rect x=\"0\" y=\"0\" width=\"100\" height=\"100\" fill=\"#ffffff\"/><g transform=\"scale(3.448)\"><g transform=\"translate(0,0)\"><path fill-rule=\"evenodd\" d=\"M8 0L8 1L10 1L10 0ZM15 0L15 1L16 1L16 2L15 2L15 3L14 3L14 2L11 2L11 4L10 4L10 3L9 3L9 2L8 2L8 5L9 5L9 6L8 6L8 7L9 7L9 8L8 8L8 10L6 10L6 9L7 9L7 8L6 8L6 9L5 9L5 10L6 10L6 11L7 11L7 12L6 12L6 13L7 13L7 14L6 14L6 15L5 15L5 14L4 14L4 13L5 13L5 12L4 12L4 13L3 13L3 11L4 11L4 10L3 10L3 9L4 9L4 8L0 8L0 11L1 11L1 12L0 12L0 14L2 14L2 15L1 15L1 16L2 16L2 17L1 17L1 18L0 18L0 19L1 19L1 18L2 18L2 19L3 19L3 20L5 20L5 16L6 16L6 17L7 17L7 18L6 18L6 19L7 19L7 20L6 20L6 21L8 21L8 22L9 22L9 21L10 21L10 23L13 23L13 24L12 24L12 25L11 25L11 24L10 24L10 27L9 27L9 25L8 25L8 29L9 29L9 28L10 28L10 29L11 29L11 28L12 28L12 26L14 26L14 29L16 29L16 28L17 28L17 29L19 29L19 28L20 28L20 29L21 29L21 28L22 28L22 27L23 27L23 29L24 29L24 28L25 28L25 29L26 29L26 28L25 28L25 27L27 27L27 29L28 29L28 27L29 27L29 24L28 24L28 22L29 22L29 19L28 19L28 21L27 21L27 19L26 19L26 18L27 18L27 17L25 17L25 16L26 16L26 15L29 15L29 13L27 13L27 12L26 12L26 13L25 13L25 14L26 14L26 15L24 15L24 14L23 14L23 13L24 13L24 12L25 12L25 11L26 11L26 10L25 10L25 9L27 9L27 11L28 11L28 12L29 12L29 11L28 11L28 10L29 10L29 8L28 8L28 9L27 9L27 8L24 8L24 9L23 9L23 11L22 11L22 12L21 12L21 11L19 11L19 10L21 10L21 9L22 9L22 8L21 8L21 9L20 9L20 7L21 7L21 6L20 6L20 2L19 2L19 5L18 5L18 4L17 4L17 3L16 3L16 2L17 2L17 0ZM19 0L19 1L20 1L20 0ZM12 3L12 5L10 5L10 6L9 6L9 7L10 7L10 8L9 8L9 9L10 9L10 10L8 10L8 12L7 12L7 13L9 13L9 12L10 12L10 13L11 13L11 11L13 11L13 10L14 10L14 12L15 12L15 13L20 13L20 14L21 14L21 16L22 16L22 17L21 17L21 19L22 19L22 20L23 20L23 18L25 18L25 17L24 17L24 15L22 15L22 14L21 14L21 12L18 12L18 11L16 11L16 9L18 9L18 8L19 8L19 7L20 7L20 6L19 6L19 7L18 7L18 5L17 5L17 4L16 4L16 5L14 5L14 6L13 6L13 7L12 7L12 5L13 5L13 3ZM16 5L16 7L15 7L15 6L14 6L14 7L15 7L15 8L14 8L14 10L15 10L15 8L18 8L18 7L17 7L17 5ZM10 6L10 7L11 7L11 8L12 8L12 7L11 7L11 6ZM23 11L23 12L22 12L22 13L23 13L23 12L24 12L24 11ZM1 12L1 13L2 13L2 14L3 14L3 13L2 13L2 12ZM12 12L12 14L8 14L8 15L6 15L6 16L8 16L8 18L7 18L7 19L8 19L8 21L9 21L9 20L10 20L10 21L11 21L11 22L12 22L12 21L11 21L11 20L12 20L12 19L11 19L11 18L12 18L12 17L13 17L13 18L17 18L17 19L16 19L16 20L15 20L15 21L14 21L14 19L13 19L13 23L14 23L14 22L15 22L15 24L14 24L14 26L15 26L15 27L16 27L16 26L17 26L17 28L18 28L18 26L17 26L17 25L20 25L20 22L19 22L19 23L18 23L18 21L17 21L17 19L18 19L18 20L20 20L20 18L18 18L18 17L17 17L17 16L18 16L18 15L19 15L19 14L17 14L17 16L16 16L16 17L15 17L15 15L16 15L16 14L15 14L15 15L14 15L14 13L13 13L13 12ZM26 13L26 14L27 14L27 13ZM12 14L12 16L11 16L11 15L9 15L9 18L8 18L8 19L9 19L9 18L10 18L10 17L12 17L12 16L13 16L13 14ZM3 15L3 17L2 17L2 18L3 18L3 17L4 17L4 15ZM19 16L19 17L20 17L20 16ZM28 16L28 17L29 17L29 16ZM24 19L24 20L25 20L25 19ZM1 20L1 21L2 21L2 20ZM15 21L15 22L16 22L16 23L17 23L17 21ZM21 21L21 24L24 24L24 21ZM22 22L22 23L23 23L23 22ZM25 22L25 23L26 23L26 24L27 24L27 22ZM15 24L15 26L16 26L16 25L17 25L17 24ZM22 25L22 26L23 26L23 25ZM24 25L24 27L25 27L25 26L27 26L27 27L28 27L28 25ZM19 26L19 27L21 27L21 26ZM0 0L0 7L7 7L7 0ZM1 1L1 6L6 6L6 1ZM2 2L2 5L5 5L5 2ZM22 0L22 7L29 7L29 0ZM23 1L23 6L28 6L28 1ZM24 2L24 5L27 5L27 2ZM0 22L0 29L7 29L7 22ZM1 23L1 28L6 28L6 23ZM2 24L2 27L5 27L5 24Z\" fill=\"#000000\"/></g></g></svg>\n", $result);
     }
 
     public function test_it_throws_an_exception_if_datatype_is_not_found()
     {
         $this->expectException(BadMethodCallException::class);
-        (new Generator)->notReal('fooBar');
+        (new Generator())->notReal('fooBar');
     }
 
     public function test_generator_can_return_illuminate_support_htmlstring()
     {
         $this->getMockBuilder(\Illuminate\Support\HtmlString::class)->getMock();
-        $this->assertInstanceOf(\Illuminate\Support\HtmlString::class, (new Generator)->generate('fooBar'));
+        $this->assertInstanceOf(\Illuminate\Support\HtmlString::class, (new Generator())->generate('fooBar'));
     }
 }

--- a/tests/ImageMergeTest.php
+++ b/tests/ImageMergeTest.php
@@ -36,6 +36,7 @@ class ImageMergeTest extends TestCase
 
     /**
      * The location of the test image that is being merged.
+     *
      * @var mixed
      */
     protected $mergeImagePath;


### PR DESCRIPTION
QR Code in Base64 encoding for KSA E-Invoicing
Example:
QrCode::KSAVat([
                                   'seller' => 'KSAExample AG',
                                   'vat' => '30136xxxxxxxxxx',
                                   'date' => '2021-12-12',
                                   'total' => '115.00',
                                   'tax' => '15.00'
  ]);