### PR TITLE
Fixes qrcode with image transparent background

### DIFF
--- a/src/ImageMerge.php
+++ b/src/ImageMerge.php
@@ -109,6 +109,7 @@ class ImageMerge
 
         $img = imagecreatetruecolor($this->sourceImage->getWidth(), $this->sourceImage->getHeight());
         imagealphablending($img, true);
+        imagesavealpha($img, true);
         $transparent = imagecolorallocatealpha($img, 0, 0, 0, 127);
         imagefill($img, 0, 0, $transparent);
 


### PR DESCRIPTION
Hi guys,

If you create a qrcode with an image, the qrcode will no longer have a transparent background. This request should fix that issue by adding `imagesavealpha()` function to `ImageMerge` class.
