### PR TITLE
Support BaconQrCode v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.2|^8.0",
       	"ext-gd": "*",
-        "bacon/bacon-qr-code": "^2.0"
+        "bacon/bacon-qr-code": "^2.0|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "~1",


### PR DESCRIPTION
Extends the BaconQrCode dependency to `^2.0|^3.0`.

The only [breaking change with v3](https://github.com/Bacon/BaconQrCode/releases/tag/v3.0.0) is dropping support for PHP versions below 8.1.