### PR TITLE
Fix deprecated nullable parameter warning in generate() method

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -166,7 +166,7 @@ class Generator
      * @throws WriterException
      * @throws InvalidArgumentException
      */
-    public function generate(string $text, string $filename = null)
+    public function generate(string $text, ?string $filename = null)
     {
         $qrCode = $this->getWriter($this->getRenderer())->writeString($text, $this->encoding, $this->errorCorrection);
 


### PR DESCRIPTION
This PR fixes a PHP 8.1+ deprecation warning by explicitly marking the $filename parameter as nullable (?string).  